### PR TITLE
Bugfix for storing error messages in request object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "http://rubygems.org"
-gem 'ruby-debug19'
 # Specify your gem's dependencies in seorority.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "http://rubygems.org"
-
+gem 'ruby-debug19'
 # Specify your gem's dependencies in seorority.gemspec
 gemspec
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,34 @@
 PATH
   remote: .
   specs:
-    rack-recaptcha (0.6.0)
+    rack-recaptcha (0.6.2)
       json
 
 GEM
   remote: http://rubygems.org/
   specs:
+    archive-tar-minitar (0.5.2)
+    columnize (0.3.4)
     fakeweb (1.3.0)
-    json (1.5.1)
-    rack (1.2.1)
+    json (1.5.3)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
+    rack (1.3.2)
     rack-test (0.5.7)
       rack (>= 1.0)
-    riot (0.12.3)
+    riot (0.12.4)
       rr
-    rr (1.0.2)
+    rr (1.0.3)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
 
 PLATFORMS
   ruby
@@ -25,3 +39,4 @@ DEPENDENCIES
   rack-test (~> 0.5.7)
   riot (~> 0.12.3)
   rr (~> 1.0.2)
+  ruby-debug19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,28 +7,14 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
-    columnize (0.3.4)
     fakeweb (1.3.0)
     json (1.5.3)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
     rack (1.3.2)
     rack-test (0.5.7)
       rack (>= 1.0)
     riot (0.12.4)
       rr
     rr (1.0.3)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
 
 PLATFORMS
   ruby
@@ -39,4 +25,3 @@ DEPENDENCIES
   rack-test (~> 0.5.7)
   riot (~> 0.12.3)
   rr (~> 1.0.2)
-  ruby-debug19

--- a/lib/rack/recaptcha/helpers.rb
+++ b/lib/rack/recaptcha/helpers.rb
@@ -34,8 +34,8 @@ module Rack
         options[:public_key] ||= Rack::Recaptcha.public_key
         path = options[:ssl] ? Rack::Recaptcha::API_SECURE_URL : Rack::Recaptcha::API_URL
         params = "k=#{options[:public_key]}"
-        error_message = defined?(request) ? request.env['recaptcha.msg'] : env['recaptcha.msg']
-        params += "&error=" + URI.encode(error_message) unless error_message.nil?
+        error_message = request.env['recaptcha.msg'] if request
+        params += "&error=" + URI.encode(error_message) unless error_message.nil? 
         html = case type.to_sym
         when :challenge
           %{<script type="text/javascript" src="#{path}/challenge?#{params}">
@@ -67,8 +67,7 @@ module Rack
       # Helper to return whether the recaptcha was accepted.
       def recaptcha_valid?
         test = Rack::Recaptcha.test_mode
-        return test unless test.nil?
-        defined?(request) ? request.env['recaptcha.valid'] : env['recaptcha.valid']
+        test.nil? ? request.env['recaptcha.valid'] : test
       end
 
     end


### PR DESCRIPTION
Recaptcha_tag will insert an error message into the
request object (0.6.0 behavior) if "request" exists, and skip this
step otherwise (0.5.0 behavior).

Also added initialization condition to fix 2 failing tests.
