### PR TITLE
Add multilingual support

### DIFF
--- a/lib/rack/recaptcha/helpers.rb
+++ b/lib/rack/recaptcha/helpers.rb
@@ -29,13 +29,15 @@ module Rack
       #  :width      - Adjust the width of the form
       #  :row        - Adjust the rows for the challenge field
       #  :cols       - Adjust the column for the challenge field
+      #  :language   - Set the language
       def recaptcha_tag(type= :noscript, options={})
         options = DEFAULT.merge(options)
         options[:public_key] ||= Rack::Recaptcha.public_key
         path = options[:ssl] ? Rack::Recaptcha::API_SECURE_URL : Rack::Recaptcha::API_URL
         params = "k=#{options[:public_key]}"
+        params += "&hl=" + uri_parser.escape(options[:language].to_s) if options[:language]
         error_message = request.env['recaptcha.msg'] if defined?(request)
-        params += "&error=" + uri_parser.escape(error_message) unless error_message.nil? 
+        params += "&error=" + uri_parser.escape(error_message) unless error_message.nil?
         html = case type.to_sym
         when :challenge
           %{<script type="text/javascript" src="#{path}/challenge?#{params}">

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -46,6 +46,7 @@ context "Rack::Recaptcha::Helpers" do
         asserts_topic('has display').matches %r{RecaptchaOptions}
         asserts_topic('has theme').matches %r{"theme":"red"}
       end
+
       context "without display" do
         setup do
           mock(helper_test.request.env).[]('recaptcha.msg').returns(nil)
@@ -62,19 +63,20 @@ context "Rack::Recaptcha::Helpers" do
     context "noscript" do
       setup do
         mock(helper_test.request.env).[]('recaptcha.msg').returns(nil)
-        helper_test.recaptcha_tag :noscript, :public_key => "hello_world_world"
+        helper_test.recaptcha_tag :noscript, :public_key => "hello_world_world", :language => :en
       end
 
       asserts_topic("iframe").matches %r{iframe}
       asserts_topic("no script tag").matches %r{<noscript>}
       asserts_topic("public key").matches %r{hello_world_world}
+      asserts_topic("has language").matches %r{hl=en}
       denies_topic("has js").matches %r{recaptcha_ajax.js}
     end
 
     context "challenge" do
       setup do
         mock(helper_test.request.env).[]('recaptcha.msg').returns(nil)
-        helper_test.recaptcha_tag(:challenge)
+        helper_test.recaptcha_tag(:challenge, :language => :en)
       end
 
       asserts_topic("has script tag").matches %r{script}
@@ -82,6 +84,7 @@ context "Rack::Recaptcha::Helpers" do
       denies_topic("has js").matches %r{recaptcha_ajax.js}
       denies_topic("has display").matches %r{RecaptchaOptions}
       asserts_topic("has public_key").matches %r{#{'0'*40}}
+      asserts_topic("has language").matches %r{hl=en}
     end
 
     context "server" do


### PR DESCRIPTION
With this tweak it's possible to force recaptcha to use a specific language, per http://code.google.com/p/recaptcha/issues/detail?id=133
